### PR TITLE
Add Support for Mixed Packages

### DIFF
--- a/.changeset/nine-jars-repair.md
+++ b/.changeset/nine-jars-repair.md
@@ -1,0 +1,5 @@
+---
+"nanobundle": patch
+---
+
+Add support for `modulde`-packages with `.cts` entrypoints and `commonjs` packages with `.mts` entrypoints

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -1871,21 +1871,21 @@ describe('getEntriesFromContext - in TypeScript project', () => {
           '/project/src/index.mts',
           '/project/src/index.ts'
         ]);
-
-      test('cjs types entry in explicit esm module', () => {
-        expect(
-          entriesFromManifest({
-            name: 'my-package',
-            type: 'module',
-            exports: {
-              types: './lib/index.d.cts'
-            }
-          }).getEntries()[0].sourceFile).toEqual([
-            '/project/src/index.ts',
-            '/project/src/index.cts'
-          ]);
       });
-    });
+
+    test('cjs types entry in explicit esm module', () => {
+      expect(
+        entriesFromManifest({
+          name: 'my-package',
+          type: 'module',
+          exports: {
+            types: './lib/index.d.cts'
+          }
+        }).getEntries()[0].sourceFile).toEqual([
+          '/project/src/index.cts',
+          '/project/src/index.ts',
+        ]);
+      });
   });
 });
 

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -1843,6 +1843,50 @@ describe('getEntriesFromContext - in TypeScript project', () => {
       ]);
     });
   });
+
+  describe('mxied TypeScript projects', () => {
+    test('esm types entry in implicit commonjs module', () => {
+      expect(
+        entriesFromManifest({
+          name: 'my-package',
+          exports: {
+            types: './lib/index.d.mts'
+          }
+        }).getEntries()[0].sourceFile).toEqual(
+          [
+            '/project/src/index.ts',
+            '/project/src/index.mts'
+          ]);
+    });
+
+    test('esm types entry in explicit commonjs module', () => {
+      expect(
+        entriesFromManifest({
+          name: 'my-package',
+          type: 'commonjs',
+          exports: {
+            types: './lib/index.d.mts'
+          }
+        }).getEntries()[0].sourceFile).toEqual([
+          '/project/src/index.ts',
+          '/project/src/index.mts'
+        ]);
+
+      test('cjs types entry in explicit esm module', () => {
+        expect(
+          entriesFromManifest({
+            name: 'my-package',
+            type: 'module',
+            exports: {
+              types: './lib/index.d.cts'
+            }
+          }).getEntries()[0].sourceFile).toEqual([
+            '/project/src/index.ts',
+            '/project/src/index.cts'
+          ]);
+      });
+    });
+  });
 });
 
 describe('common usecases', () => {

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -1854,8 +1854,8 @@ describe('getEntriesFromContext - in TypeScript project', () => {
           }
         }).getEntries()[0].sourceFile).toEqual(
           [
-            '/project/src/index.ts',
-            '/project/src/index.mts'
+            '/project/src/index.mts',
+            '/project/src/index.ts'
           ]);
     });
 
@@ -1868,8 +1868,8 @@ describe('getEntriesFromContext - in TypeScript project', () => {
             types: './lib/index.d.mts'
           }
         }).getEntries()[0].sourceFile).toEqual([
-          '/project/src/index.ts',
-          '/project/src/index.mts'
+          '/project/src/index.mts',
+          '/project/src/index.ts'
         ]);
 
       test('cjs types entry in explicit esm module', () => {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -229,18 +229,23 @@ export const getEntriesFromContext: GetEntriesFromContext = ({
       }
       case 'dts': {
         const explicitMatcher = /\.d\.(c|m)ts$/;
+        let implicitMatcher;
+        let implicitReplacement = '.ts';
         if (!useTsSource) break;
         if (preferredModule === 'commonjs') {
-          sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.c?ts$/, '.cts'));
+          implicitMatcher = /\.d\.(c?)ts$/;
+          implicitReplacement = '.cts';
+        } else if (preferredModule === 'esmodule') {
+          implicitMatcher = /\.d\.(m?)ts$/;
+          implicitReplacement = '.mts';
         }
-        if (preferredModule === 'esmodule') {
-          sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.m?ts$/, '.mts'));
+        if (implicitMatcher?.test(resolvedSourceFile)) {
+          sourceFileCandidates.add(resolvedSourceFile.replace(implicitMatcher, implicitReplacement));
+        } else if (explicitMatcher.test(resolvedSourceFile)) {
+          sourceFileCandidates.add(resolvedSourceFile.replace(explicitMatcher, '.$1ts'))
         }
         useJsx && sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)?ts$/, '.tsx'));
         sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)?ts$/, '.ts'));
-        if (explicitMatcher.test(resolvedSourceFile)) {
-          sourceFileCandidates.add(resolvedSourceFile.replace(explicitMatcher, '.$1ts'));
-        }
         break;
       }
       case 'file': {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -242,7 +242,7 @@ export const getEntriesFromContext: GetEntriesFromContext = ({
         if (implicitMatcher?.test(resolvedSourceFile)) {
           sourceFileCandidates.add(resolvedSourceFile.replace(implicitMatcher, implicitReplacement));
         } else if (explicitMatcher.test(resolvedSourceFile)) {
-          sourceFileCandidates.add(resolvedSourceFile.replace(explicitMatcher, '.$1ts'))
+          sourceFileCandidates.add(resolvedSourceFile.replace(explicitMatcher, '.$1ts'));
         }
         useJsx && sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)?ts$/, '.tsx'));
         sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)?ts$/, '.ts'));

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -228,6 +228,7 @@ export const getEntriesFromContext: GetEntriesFromContext = ({
         break;
       }
       case 'dts': {
+        const explicitMatcher = /\.d\.(c|m)ts$/;
         if (!useTsSource) break;
         if (preferredModule === 'commonjs') {
           sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.c?ts$/, '.cts'));
@@ -237,7 +238,9 @@ export const getEntriesFromContext: GetEntriesFromContext = ({
         }
         useJsx && sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)?ts$/, '.tsx'));
         sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)?ts$/, '.ts'));
-        sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)ts$/, '.$1ts'));
+        if (explicitMatcher.test(resolvedSourceFile)) {
+          sourceFileCandidates.add(resolvedSourceFile.replace(explicitMatcher, '.$1ts'));
+        }
         break;
       }
       case 'file': {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -237,6 +237,7 @@ export const getEntriesFromContext: GetEntriesFromContext = ({
         }
         useJsx && sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)?ts$/, '.tsx'));
         sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)?ts$/, '.ts'));
+        sourceFileCandidates.add(resolvedSourceFile.replace(/\.d\.(m|c)ts$/, '.$1ts'));
         break;
       }
       case 'file': {


### PR DESCRIPTION
Currently, both compiling `"type": "module"` packages with a `.cts` entrypoint and `"type": "commonjs"` packages with a `.mts` entrypoint fails due to an edge case not being taken into consideration.

Changes made in this commit will allow `.cts` files as source for `.d.cts` files and `.mts` files as source for `.d.mts` files no matter what `type` is set in the `package.json` file.

Thus, changes made in this commit will fix #108 