### PR TITLE
fix: typo in error message, variable name

### DIFF
--- a/src/tasks/buildBundleTask.ts
+++ b/src/tasks/buildBundleTask.ts
@@ -122,7 +122,7 @@ async function buildBundleGroup({
     if (!sourceFile) {
       // FIXME
       throw new BuildBundleTaskError(dedent`
-        Source file doesn not exist.
+        Source file does not exist.
 
           Expected one of
             - ${entry.sourceFile.join('\n    - ')}

--- a/src/tasks/buildTypeTask.ts
+++ b/src/tasks/buildTypeTask.ts
@@ -130,7 +130,7 @@ export async function buildTypeTask({
       ts.getPreEmitDiagnostics(program).concat(result.diagnostics),
     );
 
-    const errrorDiagnostics: Diagnostic[] = [];
+    const errorDiagnostics: Diagnostic[] = [];
 
     for (const diagnostic of allDiagnostics) {
       if (diagnosticIgnores.includes(diagnostic.code)) {
@@ -138,7 +138,7 @@ export async function buildTypeTask({
       }
       switch (diagnostic.category) {
         case ts.DiagnosticCategory.Error: {
-          errrorDiagnostics.push(diagnostic);
+          errorDiagnostics.push(diagnostic);
           break;
         }
         default: {
@@ -148,11 +148,11 @@ export async function buildTypeTask({
       }
     }
 
-    if (errrorDiagnostics.length > 0) {
+    if (errorDiagnostics.length > 0) {
       throw new BuildTypeTaskTsError(
         ts,
         host,
-        errrorDiagnostics,
+        errorDiagnostics,
       );
     }
   }


### PR DESCRIPTION
Created two separate commits as github.com does not seem to provide methods for editing multiple files in a single commit.