### PR TITLE
Drop Node'js < v18 and TypeScript < v5 as required by tsconfck v3

### DIFF
--- a/.changeset/chilled-toys-heal.md
+++ b/.changeset/chilled-toys-heal.md
@@ -1,0 +1,5 @@
+---
+"nanobundle": major
+---
+
+Drop Node'js < v18 and TypeScript < v5 as required by tsconfck v3. (#224)

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "bin.mjs"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "resolutions": {
     "browserslist": "4.21.9",
     "vite": "^5.0.0"
   },
   "peerDependencies": {
-    "typescript": "^3.7.0 || ^4.0.0 || ^5.0.0"
+    "typescript": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3985,7 +3985,7 @@ __metadata:
     vitest: "npm:^0.34.6"
     xstate: "npm:^4.35.0"
   peerDependencies:
-    typescript: ^3.7.0 || ^4.0.0 || ^5.0.0
+    typescript: ^5.0.0
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
See #224